### PR TITLE
Updated cross-links to appear in order of TOC

### DIFF
--- a/docs/error-handling-2.md
+++ b/docs/error-handling-2.md
@@ -62,5 +62,7 @@ case MathOp::DIV:
 ## Summary 
 You just created a way to not only handle the case where  `MathReceiver` is asked to divide by 0, you also created  an event to report that an error has occured. As a challenge,  try to handle more of the cases and problems discussed in [Error handling 1](./error-handling-1.md).
 
-**Next:** [Writing Unit Tests 5](./writing-unit-tests-5.md)
+## Congratulations!!!
 
+You have **finished** the MathComponent Tutorial.
+You have now experienced a significant part of F' and are ready to start building your own deployments.

--- a/docs/writing-unit-tests-4.md
+++ b/docs/writing-unit-tests-4.md
@@ -69,4 +69,4 @@ Try the following:
 
 In this section you incorprated random testing into your existing tests.
 
-**Next:** [Adding Telemetry](./adding-telemetry.md)
+**Next:** [Writing Unit Tests 5](./writing-unit-tests-5.md)

--- a/docs/writing-unit-tests-7.md
+++ b/docs/writing-unit-tests-7.md
@@ -132,7 +132,4 @@ See if your tests are working and trouble shoot any errors:
 fprime-util check 
 ```
 
-## Congratulations!!!
-
-You have **finished** the MathComponent Tutorial.
-You have now experienced a significant part of F' and are ready to start building your own deployments. 
+**Next:** [Adding Telemetry](./adding-telemetry.md)


### PR DESCRIPTION
Per the discussion on #27, I have updated the cross-links to appear in the order of the table of contents. I will open a separate discussion on the possible use of mkdocs for documentation rendering.