### PR TITLE
Updated MathModule tutorial text to match latest behavior

### DIFF
--- a/docs/creating-components-1.md
+++ b/docs/creating-components-1.md
@@ -203,13 +203,13 @@ Now you have written the FPP code for the component, but the cpp and hpp files d
 fprime-util impl 
 ```
 
-Now, In `MathSender`, you will see two new files, `MathSender.cpp-template` and `MathSender.hpp-template`. The template files are the files you just generated using the FPP model. Whenever F' generates code, it creates new file with the `-template` so as to not burn down any old code. In this case, you did not write anything in the original `MathSender.cpp` or `MathSender.hpp`, so you can use a move command to replace the old code with the new code:
+Now, In `MathSender`, you will see two new files, `MathSender.template.cpp` and `MathSender.template.hpp`. The template files are the files you just generated using the FPP model. Whenever F' generates code, it creates new file with the `.template.` so as to not burn down any old code. In this case, you did not write anything in the original `MathSender.cpp` or `MathSender.hpp`, so you can use a move command to replace the old code with the new code:
 
 
 ```shell 
 # In: MathSender
-mv MathSender.cpp-template MathSender.cpp
-mv MathSender.hpp-template MathSender.hpp
+mv MathSender.template.cpp MathSender.cpp
+mv MathSender.template.hpp MathSender.hpp
 ```
 
 Build MathSender to make sure everything worked as expected.

--- a/docs/creating-components-3.md
+++ b/docs/creating-components-3.md
@@ -228,8 +228,8 @@ Replace the original cpp and hpp files with the ones you just created:
 
 ```shell 
 # In: MathReceiver
-mv MathReceiver.cpp-template MathReceiver.cpp
-mv MathReceiver.hpp-template MathReceiver.hpp
+mv MathReceiver.template.cpp MathReceiver.cpp
+mv MathReceiver.template.hpp MathReceiver.hpp
 ```
 
 Test the build:

--- a/docs/developing-deployments.md
+++ b/docs/developing-deployments.md
@@ -16,14 +16,13 @@ Use the following command to create the deployment:
 fprime-util new --deployment
 ```
 
-When creating the deployment you will be asked two questions, answer them as follows: 
+This command will ask for some input. Respond with the following answers:
 
 ```
-[INFO] Cookiecutter: using builtin template for new deployment
-Deployment [MyDeployment]: MathDeployment
-[INFO] Found CMake file at 'fprime-tutorial-math-component/project.cmake'
-Add component Deployment to fprime-tutorial-math-component/project.cmake at end of file (yes/no)? yes
+  Deployment name (MyDeployment): MathDeployment
 ```
+
+> For any other questions, select the default response.
 
 Test the build to make sure everything is okay:
 

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -38,7 +38,7 @@ within this new project's folder. Change into the project directory and load the
 
 ```bash
 cd MathProject
-. venv/bin/activate
+. fprime-venv/bin/activate
 ```
 
 **Next:** [Defining Types](./defining-types.md)


### PR DESCRIPTION
The MathModule tutorial was slightly out of sync with the latest behavior. This fixes minor issues uncovered while walking through the tutorial. 

* Updated `-template` references
* Fixed bad call to `activate`
* Updated deployment text to account for existence of choice-based questions by using the same verbiage from the HelloWorld tutorial.