### PR TITLE
Update MathDeploymentPackets.xml

### DIFF
--- a/MathDeployment/Top/MathDeploymentPackets.xml
+++ b/MathDeployment/Top/MathDeploymentPackets.xml
@@ -52,12 +52,7 @@
         <channel name="systemResources.NON_VOLATILE_TOTAL"/>
         <channel name="systemResources.NON_VOLATILE_FREE"/>
     </packet>
-
-    <packet name="SystemRes2" id="6" level="2">
-        <channel name="systemResources.FRAMEWORK_VERSION"/>
-        <channel name="systemResources.PROJECT_VERSION"/>
-    </packet>
-
+    
     <packet name="SystemRes3" id="7" level="2">
         <channel name="systemResources.CPU"/>
         <channel name="systemResources.CPU_00"/>


### PR DESCRIPTION
Removed systemResources version related TLM channels so pr-2866 for math component CI can pass

https://github.com/nasa/fprime/pull/2866