### PR TITLE
Add space in writing-unit-tests-6.md

### DIFF
--- a/docs/writing-unit-tests-6.md
+++ b/docs/writing-unit-tests-6.md
@@ -33,7 +33,7 @@ Add a `pickF32Value` function.
 
 ```c++
 // In: MathReceiverTester.cpp
-F32MathReceiverTester ::
+F32 MathReceiverTester ::
   pickF32Value()
 {
   const F32 m = 10e6;


### PR DESCRIPTION
add `space` between `F32` and `MathReceiverTester`