### PR TITLE
Minor fixes in tutorial

### DIFF
--- a/docs/math-component.md
+++ b/docs/math-component.md
@@ -858,8 +858,8 @@ Replace the original cpp and hpp files with the ones you just created:
 
 ```shell 
 # In: MathReceiver
-mv MathReceiver.cpp-template MathReceiver.cpp
-mv MathReceiver.hpp-template MathReceiver.hpp
+mv MathReceiver.template.cpp MathReceiver.cpp
+mv MathReceiver.template.hpp MathReceiver.hpp
 ```
 
 Test the build:

--- a/docs/math-component.md
+++ b/docs/math-component.md
@@ -1565,7 +1565,18 @@ To incorporate random numbers into the existing tests you have written for `Math
 ```
 
 
-**Second,** modify `MathSenderTestMain.cpp` to include `Random.hpp`:
+**Second,** edit `MathSender/test/ut/MathSenderTester.cpp` to pick random values:
+
+```cpp
+// In: MathSenderTester.cpp
+// Within: void MathSenderTester::testDoMath(MathOp op)
+// Pick values
+const F32 val1 = STest::Pick::any();
+const F32 val2 = STest::Pick::any() + STest::Pick::inUnitInterval();
+```
+
+
+**Third,** modify `MathSenderTestMain.cpp` to include `Random.hpp`:
 
 ```cpp
 // In: MathSenderTestMain.cpp
@@ -1574,7 +1585,7 @@ To incorporate random numbers into the existing tests you have written for `Math
 ```
 
 
-**Third,** add the following line to the main function of `MathSenderTestMain.cpp`, just *before* the return statement:
+**Fourth,** add the following line to the main function of `MathSenderTestMain.cpp`, just *before* the return statement:
 
 ```cpp
 // In: MathSenderTestMain.cpp
@@ -1582,14 +1593,14 @@ To incorporate random numbers into the existing tests you have written for `Math
 STest::Random::seed();
 ```
 
-**Fourth,** modify `MathSender/CMakeLists.txt` to include STest as a build dependency:
+**Fifth,** modify `MathSender/CMakeLists.txt` to include STest as a build dependency:
 
 ```cmake 
 # In: /MathSender/CMakeLists.txt
 # Above: register_fprime_ut()
 set(UT_MOD_DEPS STest)
 ```
-**Fifth,** recompile and rerun the tests.
+**Sixth,** recompile and rerun the tests.
 
 ```shell
 # In: MathSender  

--- a/docs/math-component.md
+++ b/docs/math-component.md
@@ -964,7 +964,7 @@ void MathReceiver ::
       NATIVE_UINT_TYPE context
   )
 {
-    U32 numMsgs = this->m_queue.getNumMsgs();
+    U32 numMsgs = this->m_queue.getMessagesAvailable();
     for (U32 i = 0; i < numMsgs; ++i) {
         (void) this->doDispatch();
     }

--- a/docs/math-component.md
+++ b/docs/math-component.md
@@ -1926,7 +1926,7 @@ void MathReceiverTester ::
     // verify telemetry
 
     // check that one channel was written
-    ASSERT_TLM_SIZE(2);
+    ASSERT_TLM_SIZE(1);
     // check that it was the op channel
     ASSERT_TLM_OPERATION_SIZE(1);
     // check for the correct value of the channel


### PR DESCRIPTION
The next changes were introduced into math-component.md:

- renamed MathReceiver.*pp-template to MathReceiver.template.*pp;
- use Queue::getMessagesAvailable instead of Queue::getNumMsgs, as it has been [renamed](https://github.com/nasa/fprime/commit/d034786bc6349fb0f371a0d8ccbd891880d381d2#diff-e29c1558e78e53364b5c9612c28e8553ee80d558baa0d1c47dd3444807070751L211);
- added picking of random values in MathSenderTester.cpp;
- set the expected value for telemetry channels in MathReceiverTester::doMathOp; at this point of the tutorial, only one channel is written (OPERATION); the second one (NUMBER_OF_OPS) is added later.