### PR TITLE
Update instructions for UT creation

### DIFF
--- a/docs/math-component.md
+++ b/docs/math-component.md
@@ -1241,25 +1241,26 @@ First, let's create our Unit Test build cache:
 fprime-util generate --ut 
 ```
 
-In Components/MathSender, create a directory called test/ut
-
-```shell 
-# In: MathSender
-mkdir -p test/ut
-```
-
-Add the unit test to the build. Absolutely make sure that this is BELOW the existing stuff in the CMakeLists.txt:
+Add the unit test to the build by uncommenting the next lines at the very end of the `CMakeLists.txt` file in your `MathProject/Components/MathSender` directory:
 
 ```cmake 
 # In: MathSender/CMakeLists.txt
 # Below: register_fprime_module()
 
+### Unit Tests ###
 set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/MathSender.fpp"
+)
+set(UT_MOD_DEPS
+  STest
 )
 set(UT_AUTO_HELPERS ON)
 register_fprime_ut()
 ```
+> [!NOTE]  
+> Keep the next lines commented:  
+> ```#   "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathSenderTestMain.cpp"```  
+> ```#   "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathSenderTester.cpp"```
 
 ### Generate the Unit Test Stub 
 Generate a stub implementation of the unit tests.
@@ -1270,30 +1271,35 @@ This stub contains all the boilerplate necessary to write and run unit tests aga
 fprime-util impl --ut
 ```
 
-You have just generate three new files `MathSenderTester.cpp`, `MathSenderTester.hpp` and `MathSenderTestMain.cpp`. Move these files to the `test/ut` in MathSender using:
+You have just created `MathSender/test/ut` folder with three new files `MathSenderTester.template.cpp`, `MathSenderTester.template.hpp` and `MathSenderTestMain.template.cpp`.  
+Since this is the start of the test's implementation, we use the generated template files for our initial test implementation. Inside your `MathSender/test/ut` directory, rename the files removing the `.template` suffix:
 
-```shell 
-# In: MathSender
-mv MathSenderTester.* MathSenderTestMain.cpp test/ut
+```bash
+# In MathSender/test/ut
+mv MathSenderTester.template.hpp MathSenderTester.hpp
+mv MathSenderTester.template.cpp MathSenderTester.cpp
+mv MathSenderTestMain.template.cpp MathSenderTestMain.cpp
 ```
 
 ### Add the Tests to the Build
 
-Add `MathSenderTester.cpp` and `MathSenderTestMain.cpp` to the build. Do so by editing the CMakeLists.txt to add the 2 new source files. The UT section should now look like the following:
+Add `MathSenderTester.cpp` and `MathSenderTestMain.cpp` to the build. Do so by uncommenting the appropriate lines in the CMakeLists.txt. The UT section should now look like the following:
 
 ```cmake
 # In: MathSender/CMakeLists.txt 
+
+### Unit Tests ###
 set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/MathSender.fpp"
-  "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathSenderTester.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathSenderTestMain.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathSenderTester.cpp"
+)
+set(UT_MOD_DEPS
+  STest
 )
 set(UT_AUTO_HELPERS ON)
 register_fprime_ut()
 ```
-
-> [!NOTE]
-> Most of this is from a few steps ago, you will only be adding two lines in this step. 
 
 Build the unit test in MathSender:
 
@@ -1621,28 +1627,26 @@ In this section you incorporated random testing into your existing tests.
 
 In this section of the tutorial, you will be repeating the steps you used to create an implementation stub for `MathSender`. 
 
-### Create a Directory for the Unit Tests 
-In `Components/MathReceiver`, create a directory called test/ut 
-
-```shell 
-# In: MathReceiver
-mkdir -p test/ut
-```
-
-Add the unit test to the build. Absolutely make sure that this is BELOW the existing stuff in the CMakeLists.txt:
+### Generate the unit test stub
+Uncomment the "Unit Tests" section in the `Components/MathReceiver/CMakeLists.txt` to add unit test to the build. Make sure that lines for `MathReceiverTestMain.cpp` and `MathReceiverTester.cpp` are still commented in the CMakeLists.txt:
 
 ```cmake 
 # In: MathReceiver/CMakeLists.txt
 # Below: register_fprime_module()
 
+### Unit Tests ###
 set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/MathReceiver.fpp"
+#   "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathReceiverTestMain.cpp"
+#   "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathReceiverTester.cpp"
+)
+set(UT_MOD_DEPS
+  STest
 )
 set(UT_AUTO_HELPERS ON)
 register_fprime_ut()
 ```
 
-### Generate the unit test stub 
 Generate a stub implementation of the unit tests.
 
 ```shell 
@@ -1652,28 +1656,31 @@ fprime-util impl --ut
 > [!NOTE]
 > These commands may take a while to run.
 
-You have just generate three new files `MathReceiverTester.cpp MathReceiverTester.hpp MathReceiverTestMain.cpp`. Move these files to the test/ut directory in MathReceiver using:
+You have just generated three new files `MathReceiverTester.template.cpp`, `MathReceiverTester.template.hpp`, and `MathReceiverTestMain.template.cpp` in the `MathReceiver/test/ut/` directory. Remove the `template` suffix, so we can use them as our initial test implementation:
 
-```shell 
-# In: MathReceiver
-mv MathReceiverTester.* MathReceiverTestMain.cpp test/ut
+```bash
+# In MathReceiver/test/ut
+mv MathReceiverTester.template.hpp MathReceiverTester.hpp
+mv MathReceiverTester.template.cpp MathReceiverTester.cpp
+mv MathReceiverTestMain.template.cpp MathReceiverTestMain.cpp
 ```
 
-Add `MathReceiverTester.cpp and MathReceiverTestMain.cpp` to the build. Do so by editing the CMakeLists.txt in MathReceiver: 
+Add `MathReceiverTester.cpp` and `MathReceiverTestMain.cpp` to the build. Do so by uncommenting the appropriate lines in the CMakeLists.txt. The UT section should now look like the following:
 
 ```cmake
 # In: MathReceiver/CMakeLists.txt 
+### Unit Tests ###
 set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/MathReceiver.fpp"
-  "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathReceiverTester.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathReceiverTestMain.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathReceiverTester.cpp"
+)
+set(UT_MOD_DEPS
+  STest
 )
 set(UT_AUTO_HELPERS ON)
 register_fprime_ut()
 ```
-
-> [!NOTE]
-> Most of this is from a few steps ago, you will only be adding two lines in this step. 
 
 Build the unit test in MathReceiver:
 

--- a/docs/math-component.md
+++ b/docs/math-component.md
@@ -1241,28 +1241,8 @@ First, let's create our Unit Test build cache:
 fprime-util generate --ut 
 ```
 
-Add the unit test to the build by uncommenting the next lines at the very end of the `CMakeLists.txt` file in your `MathProject/Components/MathSender` directory:
-
-```cmake 
-# In: MathSender/CMakeLists.txt
-# Below: register_fprime_module()
-
-### Unit Tests ###
-set(UT_SOURCE_FILES
-  "${CMAKE_CURRENT_LIST_DIR}/MathSender.fpp"
-)
-set(UT_MOD_DEPS
-  STest
-)
-set(UT_AUTO_HELPERS ON)
-register_fprime_ut()
-```
-> [!NOTE]  
-> Keep the next lines commented:  
-> ```#   "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathSenderTestMain.cpp"```  
-> ```#   "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathSenderTester.cpp"```
-
 ### Generate the Unit Test Stub 
+
 Generate a stub implementation of the unit tests.
 This stub contains all the boilerplate necessary to write and run unit tests against the `MathSender` component:
 
@@ -1272,7 +1252,7 @@ fprime-util impl --ut
 ```
 
 You have just created `MathSender/test/ut` folder with three new files `MathSenderTester.template.cpp`, `MathSenderTester.template.hpp` and `MathSenderTestMain.template.cpp`.  
-Since this is the start of the test's implementation, we use the generated template files for our initial test implementation. Inside your `MathSender/test/ut` directory, rename the files removing the `.template` suffix:
+Since this is the start of the test implementation, we use the generated template files for our initial test implementation. Inside your `MathSender/test/ut` directory, rename the files removing the `.template` suffix:
 
 ```bash
 # In MathSender/test/ut
@@ -1283,7 +1263,7 @@ mv MathSenderTestMain.template.cpp MathSenderTestMain.cpp
 
 ### Add the Tests to the Build
 
-Add `MathSenderTester.cpp` and `MathSenderTestMain.cpp` to the build. Do so by uncommenting the appropriate lines in the CMakeLists.txt. The UT section should now look like the following:
+Add the unit test sources to the build by uncommenting the following lines at the very end of the `CMakeLists.txt` file in your `MathProject/Components/MathSender` directory:
 
 ```cmake
 # In: MathSender/CMakeLists.txt 
@@ -1627,26 +1607,6 @@ In this section you incorporated random testing into your existing tests.
 
 In this section of the tutorial, you will be repeating the steps you used to create an implementation stub for `MathSender`. 
 
-### Generate the unit test stub
-Uncomment the "Unit Tests" section in the `Components/MathReceiver/CMakeLists.txt` to add unit test to the build. Make sure that lines for `MathReceiverTestMain.cpp` and `MathReceiverTester.cpp` are still commented in the CMakeLists.txt:
-
-```cmake 
-# In: MathReceiver/CMakeLists.txt
-# Below: register_fprime_module()
-
-### Unit Tests ###
-set(UT_SOURCE_FILES
-  "${CMAKE_CURRENT_LIST_DIR}/MathReceiver.fpp"
-#   "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathReceiverTestMain.cpp"
-#   "${CMAKE_CURRENT_LIST_DIR}/test/ut/MathReceiverTester.cpp"
-)
-set(UT_MOD_DEPS
-  STest
-)
-set(UT_AUTO_HELPERS ON)
-register_fprime_ut()
-```
-
 Generate a stub implementation of the unit tests.
 
 ```shell 
@@ -1665,7 +1625,7 @@ mv MathReceiverTester.template.cpp MathReceiverTester.cpp
 mv MathReceiverTestMain.template.cpp MathReceiverTestMain.cpp
 ```
 
-Add `MathReceiverTester.cpp` and `MathReceiverTestMain.cpp` to the build. Do so by uncommenting the appropriate lines in the CMakeLists.txt. The UT section should now look like the following:
+Add the unit test to the build. Do so by uncommenting the appropriate lines in the CMakeLists.txt. The UT section should now look like the following:
 
 ```cmake
 # In: MathReceiver/CMakeLists.txt 


### PR DESCRIPTION
The update is caused by the next issues:
https://github.com/nasa/fprime/issues/2997 : the UT files are included into the newly created component's cmake file;
https://github.com/nasa/fprime/issues/2515 : the UT templates are generated and moved into test/ut by the fprime-util impl --ut.